### PR TITLE
Don't panic if new ScheduleRunners are added

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -175,6 +175,8 @@ pub fn schedule_runner_system(mut world: &mut World, mut resources: &mut Resourc
         schedule.run(&mut world, &mut resources);
     }
     for (entity, mut runner) in &mut world.query_mut::<(Entity, &mut ScheduleRunner)>().iter() {
-        runner.0 = entity_map.remove(&entity).unwrap();
+        if let Some(schedule) = entity_map.remove(&entity) {
+            runner.0 = schedule;
+        }
     }
 }


### PR DESCRIPTION
The previous version of the code panicked if one of the systems executed by a ScheduleRunner spawned a new ScheduleRunner. Now it checks for that condition rather than simply unwrapping.